### PR TITLE
Babel6

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,19 @@
+{
+  "presets": ["react", "es2015"],
+  "env": {
+    "development": {
+      "plugins": [
+        ["react-transform", {
+          "transforms": [{
+            "transform": "react-transform-hmr",
+            "imports": ["react"],
+            "locals": ["module"]
+          }, {
+            "transform": "react-transform-catch-errors",
+            "imports": ["react", "redbox-react"]
+          }]
+        }]
+      ]
+    }
+  }
+}

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,28 @@
+{
+  "ecmaFeatures": {
+    "jsx": true,
+    "modules": true
+  },
+  "env": {
+    "browser": true,
+    "node": true,
+    "commonjs": true,
+    "jquery": true
+  },
+  "parser": "babel-eslint",
+  "rules": {
+    "quotes": [2, "single"],
+    "strict": [2, "never"],
+    "babel/generator-star-spacing": 1,
+    "babel/new-cap": 1,
+    "babel/object-shorthand": 1,
+    "babel/no-await-in-loop": 1,
+    "react/jsx-uses-react": 2,
+    "react/jsx-uses-vars": 2,
+    "react/react-in-jsx-scope": 2
+  },
+  "plugins": [
+    "babel",
+    "react"
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 .sass-cache
 .DS_Store
 npm-debug.log
+
+npm-shrinkwrap.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
-node_modules
+node_modules/
 .sass-cache
 .DS_Store
 npm-debug.log
 
+# Unnecessary unless installing from github source instead of npm
 npm-shrinkwrap.json
+
+# These go to npm, unnecessary for .gitignore
+build/
+examples/

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+src/
+src_examples/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # React Idle Timer
 > React.js port of jQuery.idleTimer with some extras.
 
+:rocket: **Now  with [Babel 6](https://github.com/babel/babel) and [react-transform](https://github.com/gaearon/babel-plugin-react-transform) support**
+
 [![NPM](https://nodei.co/npm/react-idle-timer.png?downloads=true&stars=true)](https://npmjs.org/package/react-idle-timer/)
 
 # Installation
@@ -15,23 +17,23 @@ import IdleTimer from 'react-idle-timer';
 
 export default React.createClass({
 
-	displayName: 'YourApp',
+  displayName: 'YourApp',
 
-	render() {
-		return (
-			<IdleTimer
-				ref="idleTimer"
-				element={document}
-				activeAction={this._onActive}
-				idleAction={this._onIdle}
-				timeout={this.state.timeout}
-				format="MM-DD-YYYY HH:MM:ss.SSS">
+  render() {
+    return (
+      <IdleTimer
+        ref="idleTimer"
+        element={document}
+        activeAction={this._onActive}
+        idleAction={this._onIdle}
+        timeout={this.state.timeout}
+        format="MM-DD-YYYY HH:MM:ss.SSS">
 
-				<h1>All your children</h1>
+        <h1>All your children</h1>
 
-			</IdleTimer>
-		);
-	}
+      </IdleTimer>
+    );
+  }
 
 });
 

--- a/README.md
+++ b/README.md
@@ -6,18 +6,20 @@
 [![NPM](https://nodei.co/npm/react-idle-timer.png?downloads=true&stars=true)](https://npmjs.org/package/react-idle-timer/)
 
 # Installation
-`npm install react-idle-timer`
+`npm install react-idle-timer-babel6`
 
 # Usage
 
 > check the examples directory for a working example
 
 ```javascript
-import IdleTimer from 'react-idle-timer';
+import React from 'react'
+import IdleTimer from 'react-idle-timer-babel6';
 
-export default React.createClass({
-
-  displayName: 'YourApp',
+class YourApp extends React.Component {
+  constructor(props) {
+    super(props)
+  }
 
   render() {
     return (
@@ -32,10 +34,10 @@ export default React.createClass({
         <h1>All your children</h1>
 
       </IdleTimer>
-    );
+    )
   }
-
-});
+}
+module.exports = YourApp
 
 ```
 

--- a/build/index.js
+++ b/build/index.js
@@ -1,1 +1,330 @@
-"use strict";function _interopRequireDefault(t){return t&&t.__esModule?t:{"default":t}}Object.defineProperty(exports,"__esModule",{value:!0});var _reactAddons=require("react/addons"),_reactAddons2=_interopRequireDefault(_reactAddons),_moment=require("moment"),_moment2=_interopRequireDefault(_moment);exports["default"]=_reactAddons2["default"].createClass({displayName:"IdleTimer",propTypes:{timeout:_reactAddons2["default"].PropTypes.number,events:_reactAddons2["default"].PropTypes.arrayOf(_reactAddons2["default"].PropTypes.string),idleAction:_reactAddons2["default"].PropTypes.func,activeAction:_reactAddons2["default"].PropTypes.func,element:_reactAddons2["default"].PropTypes.oneOfType([_reactAddons2["default"].PropTypes.object,_reactAddons2["default"].PropTypes.string]),format:_reactAddons2["default"].PropTypes.string},getDefaultProps:function(){return{timeout:12e5,events:["mousemove","keydown","wheel","DOMMouseScroll","mouseWheel","mousedown","touchstart","touchmove","MSPointerDown","MSPointerMove"],idleAction:function(){},activeAction:function(){},element:document}},getInitialState:function(){return{idle:!1,oldDate:+new Date,lastActive:+new Date,remaining:null,tId:null,pageX:null,pageY:null}},componentWillMount:function(){var t=this;this.props.events.forEach(function(e){t.props.element.addEventListener(e,t._handleEvent)})},componentWillUnmount:function(){var t=this;this.props.events.forEach(function(e){t.props.element.removeEventListener(e,t._handleEvent)})},render:function(){return _reactAddons2["default"].createElement("div",null,this.props.children?this.props.children:"")},_toggleIdleState:function(){this.setState({idle:!this.state.idle}),this.state.idle?this.props.idleAction():this.props.activeAction()},_handleEvent:function(t){if(!this.state.remaining){if("mousemove"===t.type){if(t.pageX===this.state.pageX&&t.pageY===this.state.pageY)return;if("undefined"==typeof t.pageX&&"undefined"==typeof t.pageY)return;var e=+new Date-this.state.oldDate;if(200>e)return}clearTimeout(this.state.tId),this.state.idle&&this._toggleIdleState(t),this.setState({lastActive:+new Date,pageX:t.pageX,pageY:t.pageY,tId:setTimeout(this._toggleIdleState,this.props.timeout)})}},reset:function(){clearTimeout(this.state.tId),this.setState({idle:!1,oldDate:+new Date,lastActive:this.state.oldDate,remaining:null,tId:setTimeout(this._toggleIdleState,this.props.timeout)})},pause:function(){null===this.state.remaining&&(clearTimeout(this.state.tId),this.setState({remaining:this.props.timeout-(+new Date-this.state.oldDate)}))},resume:function(){null!==this.state.remaining&&(this.state.idle||this.setState({tId:setTimeout(this._toggleIdleState,this.state.remaining),remaining:null}))},getRemainingTime:function(){if(this.state.idle)return 0;if(null!=this.state.remaining)return this.state.remaining;var t=this.props.timeout-(+new Date-this.state.lastActive);return 0>t&&(t=0),t},getElapsedTime:function(){return+new Date-this.state.oldDate},getLastActiveTime:function(){return this.props.format?_moment2["default"](this.state.lastActive).format(this.props.format):this.state.lastActive},isIdle:function(){return this.state.idle}}),module.exports=exports["default"];
+'use strict';
+
+var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+
+var _redboxReact2 = require('redbox-react');
+
+var _redboxReact3 = _interopRequireDefault(_redboxReact2);
+
+var _reactTransformCatchErrors3 = require('react-transform-catch-errors');
+
+var _reactTransformCatchErrors4 = _interopRequireDefault(_reactTransformCatchErrors3);
+
+var _react2 = require('react');
+
+var _react3 = _interopRequireDefault(_react2);
+
+var _reactTransformHmr3 = require('react-transform-hmr');
+
+var _reactTransformHmr4 = _interopRequireDefault(_reactTransformHmr3);
+
+var _moment = require('moment');
+
+var _moment2 = _interopRequireDefault(_moment);
+
+var _lodash = require('lodash.bindall');
+
+var _lodash2 = _interopRequireDefault(_lodash);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var _components = {
+  IdleTimer: {
+    displayName: 'IdleTimer'
+  }
+};
+
+var _reactTransformHmr2 = (0, _reactTransformHmr4.default)({
+  filename: 'src/index.js',
+  components: _components,
+  locals: [module],
+  imports: [_react3.default]
+});
+
+var _reactTransformCatchErrors2 = (0, _reactTransformCatchErrors4.default)({
+  filename: 'src/index.js',
+  components: _components,
+  locals: [],
+  imports: [_react3.default, _redboxReact3.default]
+});
+
+function _wrapComponent(id) {
+  return function (Component) {
+    return _reactTransformHmr2(_reactTransformCatchErrors2(Component, id), id);
+  };
+} /**
+   * React Idle Timer
+   *
+   * @author  Randy Lebeau
+   * @class   IdleTimer
+   *
+   */
+
+var IdleTimer = _wrapComponent('IdleTimer')((function (_Component) {
+  _inherits(IdleTimer, _Component);
+
+  function IdleTimer(props) {
+    _classCallCheck(this, IdleTimer);
+
+    var _this = _possibleConstructorReturn(this, Object.getPrototypeOf(IdleTimer).call(this, props));
+
+    _this.state = { idle: false,
+      oldDate: +new Date(),
+      lastActive: +new Date(),
+      remaining: null,
+      tId: null,
+      pageX: null,
+      pageY: null
+    };
+
+    (0, _lodash2.default)(_this, ['_toggleIdleState', '_handleEvent', 'reset', 'pause', 'resume', 'getRemainingTime', 'getElapsedTime', 'getLastActiveTime', 'isIdle']);
+    return _this;
+  }
+
+  _createClass(IdleTimer, [{
+    key: 'componentWillMount',
+    value: function componentWillMount() {
+      var _this2 = this;
+
+      this.props.events.forEach(function (e) {
+        return _this2.props.element.addEventListener(e, _this2._handleEvent);
+      });
+    }
+  }, {
+    key: 'componentWillUnmount',
+    value: function componentWillUnmount() {
+      var _this3 = this;
+
+      this.props.events.forEach(function (e) {
+        return _this3.props.element.removeEventListener(e, _this3._handleEvent);
+      });
+    }
+  }, {
+    key: 'render',
+    value: function render() {
+      return _react3.default.createElement(
+        'div',
+        null,
+        this.props.children ? this.props.children : ''
+      );
+    }
+
+    /////////////////////
+    // Private Methods //
+    /////////////////////
+
+    /**
+     * Toggles the idle state and calls the proper action
+     *
+     * @return {void}
+     *
+     */
+
+  }, {
+    key: '_toggleIdleState',
+    value: function _toggleIdleState() {
+      // Set the state
+      this.setState({ idle: !this.state.idle });
+
+      // Fire the appropriate action
+      if (!this.state.idle) this.props.activeAction();else this.props.idleAction();
+    }
+
+    /**
+     * Event handler for supported event types
+     *
+     * @param  {Object} e event object
+     * @return {void}
+     *
+     */
+
+  }, {
+    key: '_handleEvent',
+    value: function _handleEvent(e) {
+
+      // Already idle, ignore events
+      if (this.state.remaining) return;
+
+      // Mousemove event
+      if (e.type === 'mousemove') {
+        // if coord are same, it didn't move
+        if (e.pageX === this.state.pageX && e.pageY === this.state.pageY) return;
+        // if coord don't exist how could it move
+        if (typeof e.pageX === 'undefined' && typeof e.pageY === 'undefined') return;
+        // under 200 ms is hard to do, and you would have to stop, as continuous activity will bypass this
+        var elapsed = +new Date() - this.state.oldDate;
+        if (elapsed < 200) return;
+      }
+
+      // clear any existing timeout
+      clearTimeout(this.state.tId);
+
+      // if the idle timer is enabled, flip
+      if (this.state.idle) this._toggleIdleState(e);
+
+      this.setState({ lastActive: +new Date() // store when user was last active
+        , pageX: e.pageX // update mouse coord
+        , pageY: e.pageY,
+        tId: setTimeout(this._toggleIdleState, this.props.timeout) // set a new timeout
+      });
+    }
+
+    ////////////////
+    // Public API //
+    ////////////////
+
+    /**
+     * Restore initial settings and restart timer
+     *
+     * @return {Void}
+     *
+     */
+
+  }, {
+    key: 'reset',
+    value: function reset() {
+      // reset timers
+      clearTimeout(this.state.tId);
+
+      // reset settings
+      this.setState({ idle: false,
+        oldDate: +new Date(),
+        lastActive: this.state.oldDate,
+        remaining: null,
+        tId: setTimeout(this._toggleIdleState, this.props.timeout)
+      });
+    }
+
+    /**
+     * Store remaining time and stop timer.
+     * You can pause from idle or active state.
+     *
+     * @return {Void}
+     *
+     */
+
+  }, {
+    key: 'pause',
+    value: function pause() {
+      // this is already paused
+      if (this.state.remaining !== null) return;
+
+      // clear any existing timeout
+      clearTimeout(this.state.tId);
+
+      // define how much is left on the timer
+      this.setState({ remaining: this.props.timeout - (+new Date() - this.state.oldDate) });
+    }
+
+    /**
+     * Resumes a stopped timer
+     *
+     * @return {Void}
+     *
+     */
+
+  }, {
+    key: 'resume',
+    value: function resume() {
+      // this isn't paused yet
+      if (this.state.remaining === null) return;
+
+      // start timer and clear remaining
+      if (!this.state.idle) {
+        this.setState({ tId: setTimeout(this._toggleIdleState, this.state.remaining),
+          remaining: null
+        });
+      }
+    }
+
+    /**
+     * Time remaining before idle
+     *
+     * @return {Number} Milliseconds remaining
+     *
+     */
+
+  }, {
+    key: 'getRemainingTime',
+    value: function getRemainingTime() {
+      // If idle there is no time remaining
+      if (this.state.idle) return 0;
+
+      // If its paused just return that
+      if (this.state.remaining != null) return this.state.remaining;
+
+      // Determine remaining, if negative idle didn't finish flipping, just return 0
+      var remaining = this.props.timeout - (+new Date() - this.state.lastActive);
+      if (remaining < 0) remaining = 0;
+
+      // If this is paused return that number, else return current remaining
+      return remaining;
+    }
+
+    /**
+     * How much time has elapsed
+     *
+     * @return {Timestamp}
+     *
+     */
+
+  }, {
+    key: 'getElapsedTime',
+    value: function getElapsedTime() {
+      return +new Date() - this.state.oldDate;
+    }
+
+    /**
+     * Last time the user was active
+     *
+     * @return {Timestamp}
+     *
+     */
+
+  }, {
+    key: 'getLastActiveTime',
+    value: function getLastActiveTime() {
+      if (this.props.format) return (0, _moment2.default)(this.state.lastActive).format(this.props.format);
+      return this.state.lastActive;
+    }
+
+    /**
+     * Is the user idle
+     *
+     * @return {Boolean}
+     *
+     */
+
+  }, {
+    key: 'isIdle',
+    value: function isIdle() {
+      return this.state.idle;
+    }
+  }]);
+
+  return IdleTimer;
+})(_react2.Component));
+
+IdleTimer.propTypes = { timeout: _react2.PropTypes.number // Activity timeout
+  , events: _react2.PropTypes.arrayOf(_react2.PropTypes.string) // Activity events to bind
+  , idleAction: _react2.PropTypes.func // Action to call when user becomes inactive
+  , activeAction: _react2.PropTypes.func // Action to call when user becomes active
+  , element: _react2.PropTypes.oneOfType([_react2.PropTypes.object, _react2.PropTypes.string]) // Element ref to watch activty on
+  , format: _react2.PropTypes.string
+};
+
+IdleTimer.defaultProps = { timeout: 1000 * 60 * 20 // 20 minutes
+  , events: ['mousemove', 'keydown', 'wheel', 'DOMMouseScroll', 'mouseWheel', 'mousedown', 'touchstart', 'touchmove', 'MSPointerDown', 'MSPointerMove'],
+  idleAction: function idleAction() {},
+  activeAction: function activeAction() {},
+  element: document
+};
+
+module.exports = IdleTimer;
+module.exports['default'] = IdleTimer;

--- a/examples/App.js
+++ b/examples/App.js
@@ -1,88 +1,205 @@
-import React from 'react';
-import IdleTimer from '../build/index';
+'use strict';
 
-export default React.createClass({
+var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
 
-	displayName: 'App',
+var _redboxReact2 = require('redbox-react');
 
-	getInitialState() {
-		return {
-			timeout: 3000,
-			remaining: null,
-			isIdle: false,
-			lastActive: null,
-			elapsed: null
-		}
-	},
+var _redboxReact3 = _interopRequireDefault(_redboxReact2);
 
-	componentDidMount() {
-		this.setState({
-			remaining: this.refs.idleTimer.getRemainingTime(),
-			lastActive: this.refs.idleTimer.getLastActiveTime(),
-			elapsed: this.refs.idleTimer.getElapsedTime()
-		});
+var _reactTransformCatchErrors3 = require('react-transform-catch-errors');
 
-		setInterval(() => {
-			this.setState({
-				remaining: this.refs.idleTimer.getRemainingTime(),
-				lastActive: this.refs.idleTimer.getLastActiveTime(),
-				elapsed: this.refs.idleTimer.getElapsedTime()
-			});
-		}, 1000);
-	},
+var _reactTransformCatchErrors4 = _interopRequireDefault(_reactTransformCatchErrors3);
 
-	render() {
+var _react2 = require('react');
 
-		return(
-			<IdleTimer
-				ref="idleTimer"
-				activeAction={this._onActive}
-				idleAction={this._onIdle}
-				timeout={this.state.timeout}
-				format="MM-DD-YYYY HH:MM:ss.SSS">
+var _react3 = _interopRequireDefault(_react2);
 
-				<div>
-					<h1>Timeout: {this.state.timeout}ms</h1>
-					<h1>Time Remaining: {this.state.remaining}</h1>
-					<h1>Time Elapsed: {this.state.elapsed}</h1>
-					<h1>Last Active: {this.state.lastActive}</h1>
-					<h1>Idle: {this.state.isIdle.toString()}</h1>
-				</div>
+var _reactTransformHmr3 = require('react-transform-hmr');
 
-				<div>
-					<button onClick={this._reset}>RESET</button>
-					<button onClick={this._pause}>PAUSE</button>
-					<button onClick={this._resume}>RESUME</button>
-				</div>
+var _reactTransformHmr4 = _interopRequireDefault(_reactTransformHmr3);
 
-			</IdleTimer>
-		);
-	},
+var _index = require('../build/index');
 
-	_onActive() {
-		this.setState({ isIdle: false });
-	},
+var _index2 = _interopRequireDefault(_index);
 
-	_onIdle() {
-		this.setState({ isIdle: true });
-	},
+var _lodash = require('lodash.bindall');
 
-	_changeTimeout() {
-		this.setState({
-			timeout: this.refs.timeoutInput.state.value()
-		});
-	},
+var _lodash2 = _interopRequireDefault(_lodash);
 
-	_reset() {
-		this.refs.idleTimer.reset();
-	},
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-	_pause() {
-		this.refs.idleTimer.pause();
-	},
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-	_resume() {
-		this.refs.idleTimer.resume();
-	}
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
 
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var _components = {
+  App: {
+    displayName: 'App'
+  }
+};
+
+var _reactTransformHmr2 = (0, _reactTransformHmr4.default)({
+  filename: 'src_examples/App.js',
+  components: _components,
+  locals: [module],
+  imports: [_react3.default]
 });
+
+var _reactTransformCatchErrors2 = (0, _reactTransformCatchErrors4.default)({
+  filename: 'src_examples/App.js',
+  components: _components,
+  locals: [],
+  imports: [_react3.default, _redboxReact3.default]
+});
+
+function _wrapComponent(id) {
+  return function (Component) {
+    return _reactTransformHmr2(_reactTransformCatchErrors2(Component, id), id);
+  };
+}
+
+var App = _wrapComponent('App')((function (_Component) {
+  _inherits(App, _Component);
+
+  function App(props) {
+    _classCallCheck(this, App);
+
+    var _this = _possibleConstructorReturn(this, Object.getPrototypeOf(App).call(this, props));
+
+    _this.state = { timeout: 3000,
+      remaining: null,
+      isIdle: false,
+      lastActive: null,
+      elapsed: null
+    };
+    (0, _lodash2.default)(_this, ['_onActive', '_onIdle', '_changeTimeout', '_reset', '_pause', '_resume']);
+    return _this;
+  }
+
+  _createClass(App, [{
+    key: 'componentDidMount',
+    value: function componentDidMount() {
+      var _this2 = this;
+
+      this.setState({
+        remaining: this.refs.idleTimer.getRemainingTime(),
+        lastActive: this.refs.idleTimer.getLastActiveTime(),
+        elapsed: this.refs.idleTimer.getElapsedTime()
+      });
+
+      setInterval(function () {
+        _this2.setState({
+          remaining: _this2.refs.idleTimer.getRemainingTime(),
+          lastActive: _this2.refs.idleTimer.getLastActiveTime(),
+          elapsed: _this2.refs.idleTimer.getElapsedTime()
+        });
+      }, 1000);
+    }
+  }, {
+    key: 'render',
+    value: function render() {
+      return _react3.default.createElement(
+        _index2.default,
+        {
+          ref: 'idleTimer',
+          activeAction: this._onActive,
+          idleAction: this._onIdle,
+          timeout: this.state.timeout,
+          format: 'MM-DD-YYYY HH:MM:ss.SSS' },
+        _react3.default.createElement(
+          'div',
+          null,
+          _react3.default.createElement(
+            'h1',
+            null,
+            'Timeout: ',
+            this.state.timeout,
+            'ms'
+          ),
+          _react3.default.createElement(
+            'h1',
+            null,
+            'Time Remaining: ',
+            this.state.remaining
+          ),
+          _react3.default.createElement(
+            'h1',
+            null,
+            'Time Elapsed: ',
+            this.state.elapsed
+          ),
+          _react3.default.createElement(
+            'h1',
+            null,
+            'Last Active: ',
+            this.state.lastActive
+          ),
+          _react3.default.createElement(
+            'h1',
+            null,
+            'Idle: ',
+            this.state.isIdle.toString()
+          )
+        ),
+        _react3.default.createElement(
+          'div',
+          null,
+          _react3.default.createElement(
+            'button',
+            { onClick: this._reset },
+            'RESET'
+          ),
+          _react3.default.createElement(
+            'button',
+            { onClick: this._pause },
+            'PAUSE'
+          ),
+          _react3.default.createElement(
+            'button',
+            { onClick: this._resume },
+            'RESUME'
+          )
+        )
+      );
+    }
+  }, {
+    key: '_onActive',
+    value: function _onActive() {
+      this.setState({ isIdle: false });
+    }
+  }, {
+    key: '_onIdle',
+    value: function _onIdle() {
+      this.setState({ isIdle: true });
+    }
+  }, {
+    key: '_changeTimeout',
+    value: function _changeTimeout() {
+      this.setState({
+        timeout: this.refs.timeoutInput.state.value()
+      });
+    }
+  }, {
+    key: '_reset',
+    value: function _reset() {
+      this.refs.idleTimer.reset();
+    }
+  }, {
+    key: '_pause',
+    value: function _pause() {
+      this.refs.idleTimer.pause();
+    }
+  }, {
+    key: '_resume',
+    value: function _resume() {
+      this.refs.idleTimer.resume();
+    }
+  }]);
+
+  return App;
+})(_react2.Component));
+
+module.exports = App;
+module.exports['default'] = App;

--- a/examples/Init.js
+++ b/examples/Init.js
@@ -1,32 +1,24 @@
-/**
- * Init.js
- * Initilization of the Application
- *
- * @module   Init.js
- * @author  Randy Lebeau
- *
- */
+'use strict';
 
-var React = require('react'),
-	App = require('./App');
+var _react = require('react');
 
+var _react2 = _interopRequireDefault(_react);
 
-// Display React Tools in dev
-if(process.env.NODE_ENV !== 'production') {
-	global.React = React;
-}
+var _reactDom = require('react-dom');
 
+var _App = require('./App');
 
-// Render Application
-(function() {
+var _App2 = _interopRequireDefault(_App);
 
-	React.render(
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-		<App />,
-		document.getElementById('app-container'),
-		function() {
-			// Callback after Render
-		}
-	);
-
-})();
+(0, _reactDom.render)(_react2.default.createElement(_App2.default, null), document.getElementById('app-container'), function () {
+  return console.log('Rendered!');
+}); /**
+     * Init.js
+     * Initilization of the Application
+     *
+     * @module   Init.js
+     * @author  Randy Lebeau
+     *
+     */

--- a/examples/index.html
+++ b/examples/index.html
@@ -4,32 +4,20 @@
 <!--[if IE 8]>    <html class="no-js lt-ie9 ui-mobile-rendering" lang="en"> <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js ui-mobile-rendering" lang="en"> <!--<![endif]-->
   <head>
-    <meta charset="utf-8">
-
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-
+    <meta charset="utf-8">
     <title>React Idle Timer</title>
-
     <meta name="description" content="User activity timer for React.js">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black">
     <meta name="viewport" content="user-scalable=no, initial-scale=1.0, maximum-scale=1.0, width=device-width">
-
     <link rel="apple-touch-icon" href="touch-icon-iphone.png">
     <link rel="apple-touch-icon" sizes="76x76" href="touch-icon-ipad.png">
     <link rel="apple-touch-icon" sizes="120x120" href="touch-icon-iphone-retina.png">
     <link rel="apple-touch-icon" sizes="152x152" href="touch-icon-ipad-retina.png">
-
-    <!-- <link rel="stylesheet" title="default" href="./css/style.css"> -->
-
   </head>
-
   <body>
     <div id="app-container"></div>
+    <script type="text/javascript" src="/script.js" async defer></script>
   </body>
-
-  <footer>
-    <script type="text/javascript" src="./script.js"></script>
-  </footer>
-
 </html>

--- a/examples/server.js
+++ b/examples/server.js
@@ -1,0 +1,40 @@
+'use strict';
+
+var _path = require('path');
+
+var _express = require('express');
+
+var _express2 = _interopRequireDefault(_express);
+
+var _webpack = require('webpack');
+
+var _webpack2 = _interopRequireDefault(_webpack);
+
+var _webpackDevMiddleware = require('webpack-dev-middleware');
+
+var _webpackDevMiddleware2 = _interopRequireDefault(_webpackDevMiddleware);
+
+var _webpackHotMiddleware = require('webpack-hot-middleware');
+
+var _webpackHotMiddleware2 = _interopRequireDefault(_webpackHotMiddleware);
+
+var _webpackDev = require('../webpack.dev.config');
+
+var _webpackDev2 = _interopRequireDefault(_webpackDev);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var app = (0, _express2.default)();
+var compiler = (0, _webpack2.default)(_webpackDev2.default);
+
+app.use((0, _webpackDevMiddleware2.default)(compiler, { noInfo: true,
+  publicPath: _webpackDev2.default.output.publicPath
+}));
+app.use((0, _webpackHotMiddleware2.default)(compiler));
+app.get('*', function (req, res) {
+  return res.sendFile((0, _path.join)(__dirname, 'index.html'));
+});
+
+app.listen(3000, 'localhost', function (err) {
+  if (err) console.log(err);else console.log('Listening at http://localhost:3000');
+});

--- a/package.json
+++ b/package.json
@@ -1,13 +1,18 @@
 {
   "name": "react-idle-timer-babel6",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Activity detection for React.js",
   "main": "build/index.js",
-  "files": [ "build", "examples" ],
+  "files": [
+    "build",
+    "examples"
+  ],
   "scripts": {
     "build": "babel src -d build && babel src_examples -d examples",
     "start": "node examples/server",
-    "test": "npm test"
+    "test": "npm test",
+    "prepublish": "in-publish && npm shrinkwrap || not-in-publish",
+    "postpublish": "rimraf npm-shrinkwrap.json"
   },
   "keywords": [
     "react",
@@ -27,6 +32,7 @@
     "url": "https://github.com/supremetechnopriest/react-idle-timer.git"
   },
   "dependencies": {
+    "in-publish": "^2.0.0",
     "moment": "^2.10.3",
     "react": "^0.14.3",
     "react-dom": "^0.14.3"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "clean": "rimraf build && rimraf examples/App.js && rimraf examples/init.js && rimraf examples/server.js",
     "build": "babel src -d build && babel src_examples -d examples",
-    "rebuild": "npm run clean && npm run build"
+    "rebuild": "npm run clean && npm run build",
     "start": "node examples/server",
     "test": "npm test",
     "prepublish": "in-publish && npm shrinkwrap || not-in-publish",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-idle-timer-babel6",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Activity detection for React.js",
   "main": "build/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "1.2.0",
   "description": "Activity detection for React.js",
   "main": "build/index.js",
-  "files": [ "build" ],
+  "files": [ "build", "examples" ],
   "scripts": {
     "build": "babel src -d build && babel src_examples -d examples",
-    "start": "npm run build && node examples/server",
+    "start": "node examples/server",
     "test": "npm test"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-idle-timer-babel6",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Activity detection for React.js",
   "main": "build/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -8,11 +8,14 @@
     "examples"
   ],
   "scripts": {
+    "clean": "rimraf build && rimraf examples/App.js && rimraf examples/init.js && rimraf examples/server.js",
     "build": "babel src -d build && babel src_examples -d examples",
+    "rebuild": "npm run clean && npm run build"
     "start": "node examples/server",
     "test": "npm test",
     "prepublish": "in-publish && npm shrinkwrap || not-in-publish",
-    "postpublish": "rimraf npm-shrinkwrap.json"
+    "postpublish": "rimraf npm-shrinkwrap.json",
+    "package": "npm run rebuild && npm version patch && npm publish --tag latest"
   },
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-idle-timer-babel6",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Activity detection for React.js",
   "main": "build/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-idle-timer-babel6",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Activity detection for React.js",
   "main": "build/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.2.0",
   "description": "Activity detection for React.js",
   "main": "build/index.js",
+  "files": [ "build" ],
   "scripts": {
     "build": "babel src -d build && babel src_examples -d examples",
     "start": "npm run build && node examples/server",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-idle-timer-babel6",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Activity detection for React.js",
   "main": "build/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,9 +1,11 @@
 {
-  "name": "react-idle-timer",
+  "name": "react-idle-timer-babel6",
   "version": "1.2.0",
   "description": "Activity detection for React.js",
   "main": "build/index.js",
   "scripts": {
+    "build": "babel src -d build && babel src_examples -d examples",
+    "start": "npm run build && node examples/server",
     "test": "npm test"
   },
   "keywords": [
@@ -15,6 +17,9 @@
     "active"
   ],
   "author": "Randy Lebeau",
+  "contributors": [
+    "Cole Chamberlain <cole.chamberlain@gmail.com> (https://github.com/cchamberlain)"
+  ],
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -22,14 +27,21 @@
   },
   "dependencies": {
     "moment": "^2.10.3",
-    "react": "^0.13.3"
+    "react": "^0.14.3",
+    "react-dom": "^0.14.3"
   },
   "devDependencies": {
-    "babel-core": "^5.6.7",
-    "babel-eslint": "^3.1.18",
-    "babel-loader": "^5.2.2",
-    "babel-runtime": "^5.6.7",
+    "babel-core": "^6.3.15",
+    "babel-eslint": "^5.0.0-beta4",
+    "babel-loader": "^6.2.0",
+    "babel-plugin-react-transform": "^2.0.0-beta1",
+    "babel-preset-es2015": "^6.3.13",
+    "babel-preset-react": "^6.3.13",
     "del": "^1.2.0",
+    "eslint": "^1.10.3",
+    "eslint-plugin-babel": "^3.0.0",
+    "eslint-plugin-react": "^3.11.3",
+    "express": "^4.13.3",
     "gulp": "^3.9.0",
     "gulp-babel": "^5.1.0",
     "gulp-eslint": "^0.14.0",
@@ -38,9 +50,13 @@
     "gulp-uglify": "^1.2.0",
     "gulp-util": "^3.0.6",
     "jest-cli": "^0.4.13",
-    "react-hot-loader": "^1.2.7",
-    "react-tools": "^0.13.3",
-    "webpack": "^1.9.12",
-    "webpack-dev-server": "^1.9.0"
+    "lodash.bindall": "^3.1.0",
+    "react-transform-catch-errors": "^1.0.0",
+    "react-transform-hmr": "^1.0.1",
+    "redbox-react": "^1.0.1",
+    "rimraf": "^2.4.3",
+    "webpack": "^1.12.9",
+    "webpack-dev-middleware": "^1.4.0",
+    "webpack-hot-middleware": "^2.6.0"
   }
 }

--- a/src_examples/App.js
+++ b/src_examples/App.js
@@ -1,0 +1,87 @@
+import React, { Component, PropTypes } from 'react'
+import IdleTimer from '../build/index'
+import bindAll from 'lodash.bindall'
+
+class App extends Component {
+  constructor(props) {
+    super(props)
+    this.state =  { timeout: 3000
+                  , remaining: null
+                  , isIdle: false
+                  , lastActive: null
+                  , elapsed: null
+                  }
+    bindAll(this, ['_onActive', '_onIdle', '_changeTimeout', '_reset', '_pause', '_resume'])
+  }
+  componentDidMount() {
+    this.setState({
+      remaining: this.refs.idleTimer.getRemainingTime(),
+      lastActive: this.refs.idleTimer.getLastActiveTime(),
+      elapsed: this.refs.idleTimer.getElapsedTime()
+    })
+
+    setInterval(() => {
+      this.setState({
+        remaining: this.refs.idleTimer.getRemainingTime(),
+        lastActive: this.refs.idleTimer.getLastActiveTime(),
+        elapsed: this.refs.idleTimer.getElapsedTime()
+      })
+    }, 1000)
+  }
+  render() {
+    return(
+      <IdleTimer
+        ref="idleTimer"
+        activeAction={this._onActive}
+        idleAction={this._onIdle}
+        timeout={this.state.timeout}
+        format="MM-DD-YYYY HH:MM:ss.SSS">
+
+        <div>
+          <h1>Timeout: {this.state.timeout}ms</h1>
+          <h1>Time Remaining: {this.state.remaining}</h1>
+          <h1>Time Elapsed: {this.state.elapsed}</h1>
+          <h1>Last Active: {this.state.lastActive}</h1>
+          <h1>Idle: {this.state.isIdle.toString()}</h1>
+        </div>
+
+        <div>
+          <button onClick={this._reset}>RESET</button>
+          <button onClick={this._pause}>PAUSE</button>
+          <button onClick={this._resume}>RESUME</button>
+        </div>
+
+      </IdleTimer>
+    )
+  }
+
+  _onActive() {
+    this.setState({ isIdle: false })
+  }
+
+  _onIdle() {
+    this.setState({ isIdle: true })
+  }
+
+  _changeTimeout() {
+    this.setState({
+      timeout: this.refs.timeoutInput.state.value()
+    })
+  }
+
+  _reset() {
+    this.refs.idleTimer.reset()
+  }
+
+  _pause() {
+    this.refs.idleTimer.pause()
+  }
+
+  _resume() {
+    this.refs.idleTimer.resume()
+  }
+
+}
+
+module.exports = App
+module.exports['default'] = App

--- a/src_examples/init.js
+++ b/src_examples/init.js
@@ -1,0 +1,14 @@
+/**
+ * Init.js
+ * Initilization of the Application
+ *
+ * @module   Init.js
+ * @author  Randy Lebeau
+ *
+ */
+
+import React from 'react'
+import { render } from 'react-dom'
+import App from './App'
+
+render(<App />, document.getElementById('app-container'), () => console.log('Rendered!'))

--- a/src_examples/server.js
+++ b/src_examples/server.js
@@ -1,0 +1,22 @@
+import { join } from 'path'
+import express from 'express'
+import webpack from 'webpack'
+import webpackDevMiddleware from 'webpack-dev-middleware'
+import webpackHotMiddleware from 'webpack-hot-middleware'
+import config from '../webpack.dev.config'
+
+const app = express()
+const compiler = webpack(config)
+
+app.use(webpackDevMiddleware(compiler,  { noInfo: true
+                                        , publicPath: config.output.publicPath
+                                        }))
+app.use(webpackHotMiddleware(compiler))
+app.get('*', (req, res) => res.sendFile(join(__dirname, 'index.html')))
+
+app.listen(3000, 'localhost', err => {
+  if (err)
+    console.log(err)
+  else
+    console.log('Listening at http://localhost:3000')
+})

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -9,15 +9,19 @@
 var path = require('path');
 var webpack = require('webpack');
 
+function getJsxLoader() {
+  return  { test: /\.jsx?$/
+          , loader: 'babel'
+          , exclude: /node_modules/
+          , include: [path.join(__dirname, 'examples'), path.join(__dirname, 'src')]
+          }
+}
+
 module.exports = {
-    devtool: 'source-map',
+    devtool: 'eval',
     watch: true,
-    cache: false,
-    entry: [
-        'webpack-dev-server/client?http://localhost:3002',
-        'webpack/hot/only-dev-server',
-        './examples/Init'
-    ],
+    cache: true,
+    entry: [ 'webpack-hot-middleware/client', './examples/init' ],
     resolve: {
         extensions: ['', '.jsx', '.js']
     },
@@ -27,15 +31,11 @@ module.exports = {
         publicPath: '/'
     },
     plugins: [
+        new webpack.optimize.OccurenceOrderPlugin(true),
         new webpack.HotModuleReplacementPlugin(),
         new webpack.NoErrorsPlugin()
     ],
     module: {
-        loaders: [{
-            test: /\.jsx?$/,
-            loaders: ['react-hot', 'babel-loader?optional=runtime'],
-            exclude: /node_modules/,
-            include: [path.join(__dirname, 'examples'), path.join(__dirname, 'src')]
-        }]
+        loaders: [ getJsxLoader() ]
     }
-};
+}


### PR DESCRIPTION
I needed this idle detection functionality for an app I'm working on and found that it had some issues with webpack / babel 6.  Got a little carried away and upgraded it all to es6 and overhauled the build process (all npm, haven't tested gulp).

Happy to maintain this fork for my needs but feel free to pull if you want the es6 class versions of everything and react-transform instead of deprecated react-hot-loader.

To setup just delete node_modules, run `npm i`, `npm run rebuild`, and `npm start`.  `npm run package` will clean, build, shrinkwrap (ensures dependencies on npm install are exactly what you're testing with), version (patch), and publish.