### PR TITLE
Change render to use span tags

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ class IdleTimer extends Component {
   }
 
   render() {
-    return <div>{this.props.children ? this.props.children : ''}</div>
+    return <span>{this.props.children ? this.props.children : ''}</span>
   }
 
   /////////////////////


### PR DESCRIPTION
Using divs means it'll hijack any styles in the tree (for example `height: 100%`).