### PR TITLE
updated version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-idle-timer",
-  "version": "1.6.0",
+  "version": "2.0.0",
   "description": "Activity detection for React.js",
   "main": "build/index.js",
   "files": [


### PR DESCRIPTION
While using this package at `"^1.3.3"` in an application running react 15 caused errors after the newest version of react-idle-timer was released with react v16.x.

This is due to PropTypes being removed from react 16. To keep true to semver a bump in version for this package would help distinguish to users that a breaking change may occur (react 15.x vs 16.x)