### PR TITLE
getLastActiveTime now returns a date

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ class YourApp extends React.Component {
         element={document}
         activeAction={this._onActive}
         idleAction={this._onIdle}
-        timeout={this.state.timeout}
-        format="MM-DD-YYYY HH:MM:ss.SSS">
+        timeout={this.state.timeout}>
 
         <h1>All your children</h1>
 
@@ -51,7 +50,6 @@ module.exports = YourApp
 - **idleAction** {*Function*} - Function to call on idle
 - **activeAction** {*Function*} - Function to call on active
 - **element** {*Object*} - Defaults to document, may pass a ref to another element
-- **format** {*String*} - moment.js format string applied to `lastActiveTime`
 - **startOnLoad** {*Boolean*} - Start the timer on component load.  Defaults to `true`. Set to false to wait for user action before starting timer.
 
 ## Methods
@@ -61,5 +59,5 @@ module.exports = YourApp
 - **resume()** *{Void}* - Resumes a paused idleTimer
 - **getRemainingTime()** *{Number}* - Returns the remaining time in milliseconds
 - **getElapsedTime()** *{Number}* - Returns the elapsed time in milliseconds
-- **lastActiveTime()** *{String}* - Returns the last active time as a number or a formatted string if the `format` prop is defined
+- **lastActiveTime()** *{String}* - Returns the `Date` the user was last active
 - **isIdle()** {*Boolean*} - Returns whether or not user is idle

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "url": "https://github.com/supremetechnopriest/react-idle-timer.git"
   },
   "dependencies": {
-    "date-fns": "^1.28.5",
     "prop-types": "^15.5.10",
     "react": "^16.0.0",
     "react-dom": "^16.0.0"
@@ -53,6 +52,7 @@
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-0": "^6.5.0",
+    "date-fns": "^1.28.5",
     "del": "^1.2.0",
     "eslint": "^1.10.3",
     "eslint-plugin-babel": "^3.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,6 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import format from 'date-fns/format'
 
 export default class IdleTimer extends Component {
   static propTypes = {
@@ -17,7 +16,6 @@ export default class IdleTimer extends Component {
     idleAction: PropTypes.func, // Action to call when user becomes inactive
     activeAction: PropTypes.func, // Action to call when user becomes active
     element: PropTypes.oneOfType([PropTypes.object, PropTypes.string]), // Element ref to watch activty on
-    format: PropTypes.string,
     startOnLoad: PropTypes.bool
   };
 
@@ -247,9 +245,6 @@ export default class IdleTimer extends Component {
    *
    */
   getLastActiveTime() {
-    if (this.props.format) {
-      return format(this.state.lastActive, this.props.format)
-    }
     return this.state.lastActive
   }
 

--- a/src_examples/App.js
+++ b/src_examples/App.js
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from 'react'
 import IdleTimer from '../build/index'
+import format from 'date-fns/format'
 
 export default class App extends Component {
 
@@ -31,22 +32,19 @@ export default class App extends Component {
   }
 
   render() {
-    return(
+    return (
       <IdleTimer
         ref="idleTimer"
         activeAction={this._onActive}
         idleAction={this._onIdle}
         timeout={this.state.timeout}
-        startOnLoad={true}
-        format="MM-DD-YYYY HH:MM:ss.SSS">
-
+        startOnLoad>
         <div>
-
           <div>
             <h1>Timeout: {this.state.timeout}ms</h1>
             <h1>Time Remaining: {this.state.remaining}</h1>
             <h1>Time Elapsed: {this.state.elapsed}</h1>
-            <h1>Last Active: {this.state.lastActive}</h1>
+            <h1>Last Active: {format(this.state.lastActive, 'MM-DD-YYYY HH:MM:ss.SSS')}</h1>
             <h1>Idle: {this.state.isIdle.toString()}</h1>
           </div>
 


### PR DESCRIPTION
Previously a date formatting library would be included for everyone
using this library even though it is out of scope for this project.

Now, it just returns a date and the user of the library can format it
however they choose to.

Closes #36