### PR TITLE
Fix removal of event listeners on component unmount

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -219,8 +219,13 @@ export default class IdleTimer extends Component {
     // we dont need to unbind events
     if (!IS_BROWSER) return
     // Unbind all events
-    const { element, events } = this.props
-    events.forEach(e => element.removeEventListener(e, this._handleEvent))
+    const { element, events, passive, capture } = this.props
+    events.forEach(e => {
+      element.removeEventListener(e, this._handleEvent, {
+        capture,
+        passive
+      })
+    })
   }
 
   /**


### PR DESCRIPTION
We started to see

`Warning: Can't call setState (or forceUpdate) on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method.`

warnings in our app which uses react-idle-timer to logout the user and make redirect to login page (which does not include react-idle-timer).

Debug prints in _handleEvent revealed that the event listeners were not removed even though componentWillUnmount finished successfully.

See https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener#Matching_event_listeners_for_removal for more info.
