### PR TITLE
ensure issue 94 fixes for users with stopOnIdle enabled #96

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -390,13 +390,12 @@ export default class IdleTimer extends Component {
     clearTimeout(this.tId)
     this.tId = null
 
-    if (!stopOnIdle) {
-      // Determine last time User was active, as can't rely on setTimeout ticking at the correct interval
-      const elapsedTimeSinceLastActive = new Date() - this.getLastActiveTime()
-      // If the user is idle or last active time is more than timeout, flip the idle state
-      if (idle || (!idle && elapsedTimeSinceLastActive > timeout)) {
-        this.toggleIdleState(e)
-      }
+    // Determine last time User was active, as can't rely on setTimeout ticking at the correct interval
+    const elapsedTimeSinceLastActive = new Date() - this.getLastActiveTime()
+
+    // If the user is idle or last active time is more than timeout, flip the idle state
+    if (idle && !stopOnIdle || (!idle && elapsedTimeSinceLastActive > timeout)) {
+      this.toggleIdleState(e)
     }
 
     // Store when the user was last active


### PR DESCRIPTION
The fix pushed for 94 will only have fixed where `stopOnIdle` was false, whereas this fix will ensure the toggle fallback where setTimeout has not ticked correctly will work regardless of the state of `stopOnIdle` (which is valid as this check is a fallback where `!idle`)