### PR TITLE
Adding the visibilitychange Event

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ These events are bound by default:
 - touchmove
 - MSPointerDown
 - MSPointerMove
+- visibilitychange
 
 ### Props
 - **timeout** {*Number*} - Idle timeout in milliseconds.

--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,8 @@ const DEFAULT_EVENTS = [
   'touchstart',
   'touchmove',
   'MSPointerDown',
-  'MSPointerMove'
+  'MSPointerMove',
+  'visibilitychange'
 ]
 
 /**


### PR DESCRIPTION
Adding the visibilitychange Event to the default events for React-Idle-timer. Also updated the readMe.

Would like add a new feature to react-idle-timer. Adding visibilitychange to the default events will allow a check to see if idle when browser window is opened but in the background or minimised an issue particularly on mobile devices where issues can occur such as timers like setTimeout() are throttled in background/inactive tabs to help improve performance. 

Docs for Page Visibility https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API