### PR TITLE
add missing default events to typescript events

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ There are a few breaking changes in version 4:
 - keydown
 - wheel
 - DOMMouseScroll
-- mouseWheel
+- mousewheel
 - mousedown
 - touchstart
 - touchmove

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -20,6 +20,7 @@ declare module 'react-idle-timer' {
     'copy' |
     'cut' |
     'dblclick' |
+    'DOMMouseScroll' |
     'drag' |
     'dragend' |
     'dragenter' |
@@ -54,6 +55,9 @@ declare module 'react-idle-timer' {
     'mouseout' |
     'mouseup' |
     'mousewheel' |
+    'mouseWheel' |
+    'MSPointerDown' |
+    'MSPointerMove' |
     'offline' |
     'online' |
     'open' |
@@ -88,7 +92,8 @@ declare module 'react-idle-timer' {
     'unload' |
     'volumechange' |
     'waiting' |
-    'wheel'
+    'wheel' |
+    'visibilitychange'
 
   export default class IdleTimer extends React.Component<IdleTimerProps> {
     /**

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -55,7 +55,6 @@ declare module 'react-idle-timer' {
     'mouseout' |
     'mouseup' |
     'mousewheel' |
-    'mouseWheel' |
     'MSPointerDown' |
     'MSPointerMove' |
     'offline' |

--- a/src/utils.js
+++ b/src/utils.js
@@ -24,7 +24,7 @@ export const DEFAULT_EVENTS = [
   'keydown',
   'wheel',
   'DOMMouseScroll',
-  'mouseWheel',
+  'mousewheel',
   'mousedown',
   'touchstart',
   'touchmove',


### PR DESCRIPTION
There are default events that aren't exposed to typescript which results in compilation errors.

![image](https://user-images.githubusercontent.com/5339066/95145152-40fa5a00-07c6-11eb-9e19-ae79e5e34bc9.png)

This pull request adds the missing types.