### PR TITLE
⚡️ Add getTotalActiveTime method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 4.4.0
+- Added `getTotalActiveTime` method.  Returns the total time in milliseconds the user was active.
+
 ### 4.3.7
 - Added more event types to typescript definition
 - Fixed a type-o in the default events (mouseWheel -> mousewheel)

--- a/README.md
+++ b/README.md
@@ -167,10 +167,11 @@ There are a few breaking changes in version 4:
 - **capture** {*Boolean*} - Bind events in [capture](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener) mode. Defaults to  `true`.
 
 ### Methods
-- **reset()** *{Void}* - Resets the idleTimer
-- **pause()** *{Void}* - Pauses the idleTimer
-- **resume()** *{Void}* - Resumes a paused idleTimer
-- **getRemainingTime()** *{Number}* - Returns the remaining time in milliseconds
-- **getElapsedTime()** *{Number}* - Returns the elapsed time in milliseconds
-- **getLastActiveTime()** *{Number}* - Returns the `Timestamp` the user was last active
-- **isIdle()** *{Boolean}* - Returns whether or not user is idle
+- **reset()** *{Void}* - Resets the idleTimer.
+- **pause()** *{Void}* - Pauses the idleTimer.
+- **resume()** *{Void}* - Resumes a paused idleTimer.
+- **getRemainingTime()** *{Number}* - Returns the remaining time in milliseconds.
+- **getElapsedTime()** *{Number}* - Returns the elapsed time in milliseconds.
+- **getLastActiveTime()** *{Number}* - Returns the `Timestamp` the user was last active.
+- **getTotalActiveTime()** *{Number}* - Returns the amount of time in milliseconds the user was active.
+- **isIdle()** *{Boolean}* - Returns whether or not user is idle.

--- a/src/IdleTimer.js
+++ b/src/IdleTimer.js
@@ -40,6 +40,7 @@ class IdleTimer extends Component {
       idle: false,
       oldDate: +new Date(),
       lastActive: +new Date(),
+      activeTime: null,
       remaining: null,
       pageX: null,
       pageY: null
@@ -210,7 +211,8 @@ class IdleTimer extends Component {
     // and pass the event through
     // Toggle the idle state
     this.setState((prevState) => ({
-      idle: !prevState.idle
+      idle: !prevState.idle,
+      activeTime: !prevState.idle ? this.state.activeTime + (+new Date()) - this.state.lastActive : this.state.activeTime
     }), () => {
       const { onActive, onIdle, stopOnIdle } = this.props
       const { idle } = this.state
@@ -222,6 +224,7 @@ class IdleTimer extends Component {
           // Unbind events
           this._unbindEvents()
         }
+
         onIdle(e)
       } else {
         if (!stopOnIdle) {
@@ -368,7 +371,7 @@ class IdleTimer extends Component {
   /**
    * Time remaining before idle
    * @name getRemainingTime
-   * @return {Number} Milliseconds remaining
+   * @return {number} Milliseconds remaining
    */
   getRemainingTime () {
     const { remaining, lastActive } = this.state
@@ -405,9 +408,19 @@ class IdleTimer extends Component {
   }
 
   /**
+   * Total time the user was active
+   * @name getTotalActiveTime
+   * @return {number}
+   */
+  getTotalActiveTime () {
+    const { activeTime } = this.state
+    return activeTime
+  }
+
+  /**
    * Returns wether or not the user is idle
    * @name isIdle
-   * @return {Boolean}
+   * @return {boolean}
    */
   isIdle () {
     const { idle } = this.state

--- a/src/__tests__/IdleTimer.test.js
+++ b/src/__tests__/IdleTimer.test.js
@@ -192,7 +192,7 @@ describe('IdleTimer', () => {
         timer.instance().reset()
         expect(timer.state('idle')).toBe(false)
         expect(timer.instance().tId).toBeGreaterThan(0)
-        expect(timer.instance().getRemainingTime()).toBeAround(props.timeout, 3)
+        expect(timer.instance().getRemainingTime()).toBeAround(props.timeout, 5)
         simulant.fire(document, 'mousedown')
 
         setTimeout(() => {
@@ -572,11 +572,13 @@ describe('IdleTimer', () => {
         const timer = idleTimer()
         setTimeout(() => {
           expect(timer.instance().getTotalActiveTime()).toBeAround(props.timeout, 5)
-          simulant.fire(document, 'mousedown')
           setTimeout(() => {
-            expect(timer.instance().getTotalActiveTime()).toBeAround(props.timeout * 2, 10)
-            done()
-          }, 300)
+            simulant.fire(document, 'mousedown')
+            setTimeout(() => {
+              expect(timer.instance().getTotalActiveTime()).toBeAround(props.timeout * 2, 10)
+              done()
+            }, 300)
+          }, 100)
         }, 300)
       })
     })

--- a/src/__tests__/IdleTimer.test.js
+++ b/src/__tests__/IdleTimer.test.js
@@ -566,6 +566,21 @@ describe('IdleTimer', () => {
       })
     })
 
+    describe('getTotalActiveTime', () => {
+      it('Should get the total active time', done => {
+        props.timeout = 200
+        const timer = idleTimer()
+        setTimeout(() => {
+          expect(timer.instance().getTotalActiveTime()).toBeAround(props.timeout, 5)
+          simulant.fire(document, 'mousedown')
+          setTimeout(() => {
+            expect(timer.instance().getTotalActiveTime()).toBeAround(props.timeout * 2, 10)
+            done()
+          }, 300)
+        }, 300)
+      })
+    })
+
     describe('isIdle', () => {
       it('Should get the idle state', (done) => {
         props.timeout = 200

--- a/src/__tests__/useIdleTimer.test.js
+++ b/src/__tests__/useIdleTimer.test.js
@@ -427,7 +427,22 @@ describe('useIdleTimer', () => {
           setTimeout(() => {
             expect(result.current.getLastActiveTime()).toBe(lastActive)
             done()
-          }, 500)
+          }, 300)
+        })
+      })
+
+      describe('getTotalActiveTime', () => {
+        it('Should get the total active time', done => {
+          props.timeout = 200
+          const { result } = idleTimer()
+          setTimeout(() => {
+            expect(result.current.getTotalActiveTime()).toBeAround(props.timeout, 5)
+            simulant.fire(document, 'mousedown')
+            setTimeout(() => {
+              expect(result.current.getTotalActiveTime()).toBeAround(props.timeout * 2, 10)
+              done()
+            }, 300)
+          }, 300)
         })
       })
 

--- a/src/__tests__/useIdleTimer.test.js
+++ b/src/__tests__/useIdleTimer.test.js
@@ -437,11 +437,13 @@ describe('useIdleTimer', () => {
           const { result } = idleTimer()
           setTimeout(() => {
             expect(result.current.getTotalActiveTime()).toBeAround(props.timeout, 5)
-            simulant.fire(document, 'mousedown')
             setTimeout(() => {
-              expect(result.current.getTotalActiveTime()).toBeAround(props.timeout * 2, 10)
-              done()
-            }, 300)
+              simulant.fire(document, 'mousedown')
+              setTimeout(() => {
+                expect(result.current.getTotalActiveTime()).toBeAround(props.timeout * 2, 10)
+                done()
+              }, 300)
+            }, 100)
           }, 300)
         })
       })

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -231,6 +231,11 @@ declare module 'react-idle-timer' {
     getLastActiveTime(): number
 
     /**
+     * Total time in milliseconds user was active
+     */
+    getTotalActiveTime(): number
+
+    /**
      * Returns wether or not the user is idle
      */
     isIdle(): boolean

--- a/src/useIdleTimer.js
+++ b/src/useIdleTimer.js
@@ -42,6 +42,7 @@ function useIdleTimer ({
   const pageX = useRef(null)
   const pageY = useRef(null)
   const tId = useRef(null)
+  const activeTime = useRef(0)
 
   // Event emitters
   const emitOnIdle = useRef(onIdle)
@@ -64,6 +65,7 @@ function useIdleTimer ({
         // Unbind events
         _unbindEvents()
       }
+      activeTime.current += (+new Date()) - lastActive.current
       emitOnIdle.current(e)
     } else {
       if (!stopOnIdle) {
@@ -178,7 +180,7 @@ function useIdleTimer ({
   /**
    * Time remaining before idle
    * @name getRemainingTime
-   * @return {Number} Milliseconds remaining
+   * @return {number} Milliseconds remaining
    */
   const getRemainingTime = () => {
     // If idle there is no time remaining
@@ -196,9 +198,7 @@ function useIdleTimer ({
    * @name getElapsedTime
    * @return {Timestamp}
    */
-  const getElapsedTime = () => {
-    return (+new Date()) - oldDate.current
-  }
+  const getElapsedTime = () => (+new Date()) - oldDate.current
 
   /**
    * Last time the user was active
@@ -206,6 +206,13 @@ function useIdleTimer ({
    * @return {Timestamp}
    */
   const getLastActiveTime = () => lastActive.current
+
+  /**
+   * Get the total time user is active
+   * @name getTotalActiveTime
+   * @return {number} Milliseconds active
+   */
+  const getTotalActiveTime = () => activeTime.current
 
   /**
    * Returns wether or not the user is idle
@@ -333,6 +340,7 @@ function useIdleTimer ({
     reset,
     resume,
     getLastActiveTime,
+    getTotalActiveTime,
     getElapsedTime,
     getRemainingTime
   }
@@ -347,7 +355,7 @@ useIdleTimer.propTypes = {
   /**
    * Activity Timeout in milliseconds
    * default: 1200000
-   * @type {Number}
+   * @type {number}
    */
   timeout: PropTypes.number,
   /**
@@ -377,19 +385,19 @@ useIdleTimer.propTypes = {
   /**
    * Debounce the onAction function by setting delay in milliseconds
    * default: 0
-   * @type {Number}
+   * @type {number}
    */
   debounce: PropTypes.number,
   /**
    * Throttle the onAction function by setting delay in milliseconds
    * default: 0
-   * @type {Number}
+   * @type {number}
    */
   throttle: PropTypes.number,
   /**
    * Throttle the event handler function by setting delay in milliseconds
    * default: 200
-   * @type {Number}
+   * @type {number}
    */
   eventsThrottle: PropTypes.number,
   /**


### PR DESCRIPTION
This PR adds a `getTotalActiveTime` method that returns the total amount of milliseconds a user is active.  