### PR TITLE
Add web worker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-idle-timer",
-  "version": "4.6.3-rc.3",
+  "version": "4.6.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4169,29 +4169,6 @@
         "@rollup/pluginutils": "^3.1.0"
       }
     },
-    "@rollup/plugin-commonjs": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-19.0.0.tgz",
-      "integrity": "sha512-adTpD6ATGbehdaQoZQ6ipDFhdjqsTgpOAhFiPwl+dzre4pPshsecptDPyEFb61JMJ1+mGljktaC4jI8ARMSNyw==",
-      "dev": true,
-      "requires": {
-        "@rollup/pluginutils": "^3.1.0",
-        "commondir": "^1.0.1",
-        "estree-walker": "^2.0.1",
-        "glob": "^7.1.6",
-        "is-reference": "^1.2.1",
-        "magic-string": "^0.25.7",
-        "resolve": "^1.17.0"
-      },
-      "dependencies": {
-        "estree-walker": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-          "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-          "dev": true
-        }
-      }
-    },
     "@rollup/plugin-node-resolve": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.0.tgz",
@@ -5739,12 +5716,6 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
     },
-    "commondir": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
-      "dev": true
-    },
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -7096,6 +7067,25 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-unique-numbers": {
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/fast-unique-numbers/-/fast-unique-numbers-6.0.9.tgz",
+      "integrity": "sha512-AsAHIl9JebIZoEjlu53gFAP1nPTkjHp8cbBVFDfYkYxTWF93Edxi/Q/ybHjj264XRO2wMPIuP6vkjdABtEsWlw==",
+      "requires": {
+        "@babel/runtime": "^7.16.3",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.16.3",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.3.tgz",
+          "integrity": "sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
     "fb-watchman": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
@@ -7793,15 +7783,6 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz",
       "integrity": "sha1-DFLlS8yjkbssSUsh6GJtczbG45c=",
       "dev": true
-    },
-    "is-reference": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
-      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
-      "dev": true,
-      "requires": {
-        "@types/estree": "*"
-      }
     },
     "is-regex": {
       "version": "1.1.0",
@@ -9554,15 +9535,6 @@
         "yallist": "^4.0.0"
       }
     },
-    "magic-string": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
-      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
-      "dev": true,
-      "requires": {
-        "sourcemap-codec": "^1.4.4"
-      }
-    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -10989,8 +10961,7 @@
     "regenerator-runtime": {
       "version": "0.13.7",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
-      "dev": true
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
     },
     "regenerator-transform": {
       "version": "0.14.5",
@@ -11746,12 +11717,6 @@
       "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
       "dev": true
     },
-    "sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "dev": true
-    },
     "spdx-correct": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
@@ -12397,6 +12362,11 @@
         }
       }
     },
+    "tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -12807,6 +12777,67 @@
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
+    },
+    "worker-timers": {
+      "version": "7.0.42",
+      "resolved": "https://registry.npmjs.org/worker-timers/-/worker-timers-7.0.42.tgz",
+      "integrity": "sha512-EfDUS5qf+xe0TvJsAIKpIUTXRk9SYC2XX5tScgOfgCwci1LUGswtso09q+mh4LerHgWcdrCraYeEpdsd41iVlw==",
+      "requires": {
+        "@babel/runtime": "^7.16.3",
+        "tslib": "^2.3.1",
+        "worker-timers-broker": "^6.0.63",
+        "worker-timers-worker": "^7.0.30"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.16.3",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.3.tgz",
+          "integrity": "sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "worker-timers-broker": {
+      "version": "6.0.63",
+      "resolved": "https://registry.npmjs.org/worker-timers-broker/-/worker-timers-broker-6.0.63.tgz",
+      "integrity": "sha512-cOYMsGKP7k/UUODVYCumYxAOsHEeg1aAhhLzuJm2WVsLjra1faoj3D1L6nt472PrvDXgqP+PGCOiHQYKNXltiQ==",
+      "requires": {
+        "@babel/runtime": "^7.16.3",
+        "fast-unique-numbers": "^6.0.9",
+        "tslib": "^2.3.1",
+        "worker-timers-worker": "^7.0.30"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.16.3",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.3.tgz",
+          "integrity": "sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "worker-timers-worker": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/worker-timers-worker/-/worker-timers-worker-7.0.30.tgz",
+      "integrity": "sha512-jASIdgMm08dRaUTLQ5w6Nxaz4qTNxMV6ygTSS93SxTXnWTQuwzvaft7LAy8T3kxRrO4VOr4n6rvSHEqITI7LHg==",
+      "requires": {
+        "@babel/runtime": "^7.16.3",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.16.3",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.3.tgz",
+          "integrity": "sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
     },
     "wrap-ansi": {
       "version": "6.2.0",

--- a/package.json
+++ b/package.json
@@ -100,5 +100,8 @@
       "examples/**",
       "**/__tests__/**"
     ]
+  },
+  "dependencies": {
+    "worker-timers": "^7.0.42"
   }
 }

--- a/src/IdleTimer.js
+++ b/src/IdleTimer.js
@@ -12,6 +12,7 @@
 
 import { Component } from 'react'
 import PropTypes from 'prop-types'
+import timer from './timer'
 import { TabManager } from './TabManager'
 import { IS_BROWSER, DEFAULT_ELEMENT, DEFAULT_EVENTS, debounced, throttled } from './utils'
 
@@ -173,7 +174,7 @@ class IdleTimer extends Component {
    */
   componentWillUnmount () {
     // Clear timeout to prevent delayed state changes
-    clearTimeout(this.tId)
+    timer.clearTimeout(this.tId)
     this._unbindEvents(true)
     // Cancel any debounced onAction handlers
     if (this._onAction.cancel) this._onAction.cancel()
@@ -294,7 +295,7 @@ class IdleTimer extends Component {
       if (idle) {
         if (stopOnIdle) {
           // Clear any existing timeout
-          clearTimeout(this.tId)
+          timer.clearTimeout(this.tId)
           this.tId = null
           // Unbind events
           this._unbindEvents()
@@ -355,10 +356,10 @@ class IdleTimer extends Component {
     }
 
     // Clear any existing timeout
-    clearTimeout(this.tId)
+    timer.clearTimeout(this.tId)
     this.tId = null
 
-    // Determine last time User was active, as can't rely on setTimeout ticking at the correct interval
+    // Determine last time User was active, as can't rely on timer.setTimeout ticking at the correct interval
     const elapsedTimeSinceLastActive = +new Date() - this.getLastActiveTime()
 
     // If the user is idle or last active time is more than timeout, flip the idle state
@@ -378,10 +379,10 @@ class IdleTimer extends Component {
     // set a new timeout
     if (idle) {
       if (!stopOnIdle) {
-        this.tId = setTimeout(this._toggleIdleState, timeout)
+        this.tId = timer.setTimeout(this._toggleIdleState, timeout)
       }
     } else {
-      this.tId = setTimeout(this._toggleIdleState, timeout)
+      this.tId = timer.setTimeout(this._toggleIdleState, timeout)
     }
   }
 
@@ -391,7 +392,7 @@ class IdleTimer extends Component {
    */
   start (remote = true) {
     // Clear timeout
-    clearTimeout(this.tId)
+    timer.clearTimeout(this.tId)
     this.tId = null
 
     // Bind the events
@@ -416,7 +417,7 @@ class IdleTimer extends Component {
 
     // Set new timeout
     const { timeout } = this.props
-    this.tId = setTimeout(this._toggleIdleState, timeout)
+    this.tId = timer.setTimeout(this._toggleIdleState, timeout)
   }
 
   /**
@@ -425,7 +426,7 @@ class IdleTimer extends Component {
    */
   reset (remote = false) {
     // Clear timeout
-    clearTimeout(this.tId)
+    timer.clearTimeout(this.tId)
     this.tId = null
 
     // Bind the events
@@ -459,7 +460,7 @@ class IdleTimer extends Component {
 
     // Set new timeout
     const { timeout } = this.props
-    this.tId = setTimeout(this._toggleIdleState, timeout)
+    this.tId = timer.setTimeout(this._toggleIdleState, timeout)
   }
 
   /**
@@ -475,7 +476,7 @@ class IdleTimer extends Component {
     this._unbindEvents()
 
     // Clear existing timeout
-    clearTimeout(this.tId)
+    timer.clearTimeout(this.tId)
     this.tId = null
 
     // Send event to other tabs
@@ -516,7 +517,7 @@ class IdleTimer extends Component {
     // if we are in the active state
     if (!idle) {
       // Set a new timeout
-      this.tId = setTimeout(this._toggleIdleState, remaining)
+      this.tId = timer.setTimeout(this._toggleIdleState, remaining)
       // Set new state
       this.setState({ remaining: null, lastActive: +new Date() })
     }

--- a/src/MessageChannel/leaderElection.js
+++ b/src/MessageChannel/leaderElection.js
@@ -1,3 +1,4 @@
+import timer from '../timer'
 import { IS_BROWSER, sleep, randomToken } from '../utils'
 
 class LeaderElection {
@@ -122,7 +123,7 @@ class LeaderElection {
 
     await this.onBeforeDie()
     this._listeners.forEach(listener => this._channel.removeEventListener('internal', listener))
-    this._intervals.forEach(interval => clearInterval(interval))
+    this._intervals.forEach(interval => timer.clearInterval(interval))
     this._unloadFns.forEach(uFn => {
       if (IS_BROWSER) {
         window.removeEventListener(uFn[0], uFn[1])
@@ -144,7 +145,7 @@ function _awaitLeadershipOnce (leaderElector) {
         return
       }
       resolved = true
-      clearInterval(interval)
+      timer.clearInterval(interval)
       leaderElector._channel.removeEventListener('internal', whenDeathListener)
       resolve(true)
     }
@@ -157,7 +158,7 @@ function _awaitLeadershipOnce (leaderElector) {
     })
 
     // try on fallbackInterval
-    const interval = setInterval(() => {
+    const interval = timer.setInterval(() => {
       /* istanbul ignore next */
       leaderElector.applyOnce().then(() => {
         if (leaderElector.isLeader) {

--- a/src/MessageChannel/methods/simulate.js
+++ b/src/MessageChannel/methods/simulate.js
@@ -1,3 +1,4 @@
+import timer from '../../timer'
 import { microSeconds } from '../../utils'
 
 export const type = 'simulate'
@@ -19,7 +20,7 @@ export function close (channelState) {
 }
 
 export function postMessage (channelState, messageJson) {
-  return new Promise(resolve => setTimeout(() => {
+  return new Promise(resolve => timer.setTimeout(() => {
     const channelArray = Array.from(SIMULATE_CHANNELS)
     channelArray
       .filter(channel => channel.name === channelState.name)

--- a/src/timer.js
+++ b/src/timer.js
@@ -1,0 +1,39 @@
+import * as workerTimers from 'worker-timers'
+
+const isWebWorkerSupported = !!window.Worker && typeof Worker !== 'undefined'
+
+const timer = {}
+
+timer.clearInterval = (intervalId) => {
+  if (isWebWorkerSupported) {
+    workerTimers.clearInterval(intervalId)
+  } else {
+    clearInterval(intervalId)
+  }
+}
+
+timer.clearTimeout = (timeoutId) => {
+  if (isWebWorkerSupported) {
+    workerTimers.clearTimeout(timeoutId)
+  } else {
+    clearTimeout(timeoutId)
+  }
+}
+
+timer.setInterval = (callback, delay) => {
+  if (isWebWorkerSupported) {
+    workerTimers.setInterval(callback, delay)
+  } else {
+    setInterval(callback, delay)
+  }
+}
+
+timer.setTimeout = (callback, delay) => {
+  if (isWebWorkerSupported) {
+    workerTimers.setTimeout(callback, delay)
+  } else {
+    setTimeout(callback, delay)
+  }
+}
+
+export default timer

--- a/src/useIdleTimer.js
+++ b/src/useIdleTimer.js
@@ -12,6 +12,7 @@
 
 import { useEffect, useRef, useMemo } from 'react'
 import PropTypes from 'prop-types'
+import timer from './timer'
 import { TabManager } from './TabManager'
 import { IS_BROWSER, DEFAULT_ELEMENT, DEFAULT_EVENTS, debounced, throttled } from './utils'
 
@@ -113,7 +114,7 @@ function useIdleTimer ({
     if (nextIdle) {
       if (stopOnIdle) {
         // Clear any existing timeout
-        clearTimeout(tId.current)
+        timer.clearTimeout(tId.current)
         tId.current = null
         // Unbind events
         _unbindEvents()
@@ -168,10 +169,10 @@ function useIdleTimer ({
     }
 
     // Clear any existing timeout
-    clearTimeout(tId.current)
+    timer.clearTimeout(tId.current)
     tId.current = null
 
-    // Determine last time User was active, as can't rely on setTimeout ticking at the correct interval
+    // Determine last time User was active, as can't rely on timer.setTimeout ticking at the correct interval
     const elapsedTimeSinceLastActive = +new Date() - getLastActiveTime()
 
     // If the user is idle or last active time is more than timeout, flip the idle state
@@ -190,7 +191,7 @@ function useIdleTimer ({
 
     // If the user is active, set a new timeout
     if (!idle.current) {
-      tId.current = setTimeout(_toggleIdleState, _timeout.current)
+      tId.current = timer.setTimeout(_toggleIdleState, _timeout.current)
     }
   }
 
@@ -317,7 +318,7 @@ function useIdleTimer ({
   */
   const start = (remote = false) => {
     // Clear timeout
-    clearTimeout(tId.current)
+    timer.clearTimeout(tId.current)
     tId.current = null
 
     // Bind the events
@@ -339,7 +340,7 @@ function useIdleTimer ({
     }
 
     // Set new timeout
-    tId.current = setTimeout(_toggleIdleState, _timeout.current)
+    tId.current = timer.setTimeout(_toggleIdleState, _timeout.current)
   }
 
   /**
@@ -348,7 +349,7 @@ function useIdleTimer ({
   */
   const reset = (remote = false) => {
     // Clear timeout
-    clearTimeout(tId.current)
+    timer.clearTimeout(tId.current)
     tId.current = null
 
     // Bind the events
@@ -380,7 +381,7 @@ function useIdleTimer ({
     }
 
     // Set new timeout
-    tId.current = setTimeout(_toggleIdleState, _timeout.current)
+    tId.current = timer.setTimeout(_toggleIdleState, _timeout.current)
   }
 
   /**
@@ -395,7 +396,7 @@ function useIdleTimer ({
     _unbindEvents()
 
     // Clear existing timeout
-    clearTimeout(tId.current)
+    timer.clearTimeout(tId.current)
     tId.current = null
 
     // Define how much is left on the timer
@@ -424,7 +425,7 @@ function useIdleTimer ({
     // if we are in the idle state
     if (!idle.current) {
       // Set a new timeout
-      tId.current = setTimeout(_toggleIdleState, remaining.current)
+      tId.current = timer.setTimeout(_toggleIdleState, remaining.current)
       // Set states
       remaining.current = null
       lastActive.current = +new Date()
@@ -470,7 +471,7 @@ function useIdleTimer ({
     // If startOnMount is enabled, start the timer
     if (startManually) {
       return async () => {
-        clearTimeout(tId.current)
+        timer.clearTimeout(tId.current)
         _unbindEvents(true)
         if (crossTab) await manager.current.close()
       }
@@ -484,7 +485,7 @@ function useIdleTimer ({
 
     // Clear and unbind on unmount
     return async () => {
-      clearTimeout(tId.current)
+      timer.clearTimeout(tId.current)
       _unbindEvents(true)
       if (intermediateOnAction.cancel) intermediateOnAction.cancel()
       if (crossTab) await manager.current.close()

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,5 @@
+import timer from './timer'
+
 /**
  * Determine if we are in a browser
  * or a server environment
@@ -47,16 +49,16 @@ export function debounced (fn, delay) {
   let timerId
   function result (...args) {
     if (timerId) {
-      clearTimeout(timerId)
+      timer.clearTimeout(timerId)
     }
-    timerId = setTimeout(() => {
+    timerId = timer.setTimeout(() => {
       fn(...args)
       timerId = null
     }, delay)
   }
 
   result.cancel = function () {
-    clearTimeout(timerId)
+    timer.clearTimeout(timerId)
   }
 
   return result
@@ -137,7 +139,7 @@ export function isPromise (obj) {
  * @private
  */
 export function sleep (time = 0) {
-  return new Promise(resolve => setTimeout(resolve, time))
+  return new Promise(resolve => timer.setTimeout(resolve, time))
 }
 
 /**


### PR DESCRIPTION
Used Web Worker to check for setTimeout and setIntervals.

As Web Worker's are free to run even on background, which solves the issue of idle timer not working due to the browser keeping the Tab on Sleep.

Issue Introduced in Chrome 87: https://searchenterprisedesktop.techtarget.com/news/252501600/Google-lowers-power-use-in-latest-Chrome-update



With the help of Web Workers and their implementation for Timeout and Interval functions, the checks will occur in the background, where Web Worker won't be paused even if JS Script is kept to sleep/paused. Allowing the Idle timer to work properly.


I have created a small Utility function as well to check if the browser supports web worker, else default back to window timeout and interval functions.