### PR TITLE
:memo: fix URLs

### DIFF
--- a/docs/pages/docs/api/methods.mdx
+++ b/docs/pages/docs/api/methods.mdx
@@ -5,8 +5,8 @@ description: IdleTimer methods
 
 Methods are the API that is returned by IdleTimer. You can interface 
 with your IdleTimer instance by using the following functions. Examples of 
-how to use them can be found in the [hook](/docs/api/useIdleTimer) 
-and [higher order component](/docs/api/withIdleTimer) docs.
+how to use them can be found in the [hook](/docs/api/use-idle-timer) 
+and [higher order component](/docs/api/with-idle-timer) docs.
 
 ### start
 <Property 

--- a/docs/pages/docs/api/props.mdx
+++ b/docs/pages/docs/api/props.mdx
@@ -7,8 +7,8 @@ Props are the configuration options that can be passed to `useIdleTimer` or
 `withIdleTimer`. All props are optional and have sensible defaults. If a prop
 is updated dynamically, IdleTimer will be automatically restarted with the new
 set of properties. Examples of how they are used can be found in the 
-[hook](/docs/api/useIdleTimer) and 
-[higher order component](/docs/api/withIdleTimer) docs.
+[hook](/docs/api/use-idle-timer) and 
+[higher order component](/docs/api/with-idle-timer) docs.
 
 ### timeout
 <Property 

--- a/docs/pages/docs/api/types.mdx
+++ b/docs/pages/docs/api/types.mdx
@@ -5,8 +5,8 @@ description: Typescript types included with IdleTimer package
 
 IdleTimer exports its internal types for working in Typescript projects.
 All the types you will need are outlined below. Examples of how to use them 
-can be found in the [hook](/docs/api/useIdleTimer) 
-and [higher order component](/docs/api/withIdleTimer) docs.
+can be found in the [hook](/docs/api/use-idle-timer) 
+and [higher order component](/docs/api/with-idle-timer) docs.
 
 ## IIdleTimerProps
 


### PR DESCRIPTION
Noticed some broken links while browsing the docs. Updating the URLs in the markdown links seemed like a lighter change than updating the paths referenced in `docs.sidebar.json`.

https://github.com/SupremeTechnopriest/react-idle-timer/blob/0ea15ac90d19303c16b5d9c03bac149d64ae3e2e/docs/configs/docs.sidebar.json#L60-L67