### PR TITLE
⚡ Add PointerEvents types to EventType.ts.

### DIFF
--- a/src/types/EventsType.ts
+++ b/src/types/EventsType.ts
@@ -31,6 +31,7 @@ export type EventsType =
   'focusout' |
   'fullscreenchange' |
   'fullscreenerror' |
+  'gotpointercapture' |
   'hashchange' |
   'input' |
   'invalid' |
@@ -41,6 +42,7 @@ export type EventsType =
   'loadeddata' |
   'loadedmetadata' |
   'loadstart' |
+  'lostpointercapture' |
   'message' |
   'mousedown' |
   'mouseenter' |
@@ -61,6 +63,14 @@ export type EventsType =
   'pause' |
   'play' |
   'playing' |
+  'pointercancel' |
+  'pointerdown' |
+  'pointerenter' |
+  'pointerleave' |
+  'pointermove' |
+  'pointerout' |
+  'pointerover' |
+  'pointerup' |
   'popstate' |
   'progress' |
   'ratechange' |


### PR DESCRIPTION
Closes #287 
Added the [pointer event types](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent) below to the `event` prop for `useIdleTimer` or `withIdleTimer`. 

I don't personally use all these events but according to [MDN](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent), it seems like they're all valid and supported.

```
pointerover
pointerenter
pointerdown
pointermove
pointerup
pointercancel
pointerout
pointerleave
gotpointercapture
lostpointercapture
```

I was using the workaround below to add more events on a per-project basis, but it may not be easy for all users to implement. I think it's easier if this library supports valid event types according to the W3C specs.

```diff
- import { useIdleTimer } from 'react-idle-timer';
+ import { EVENTS, useIdleTimer } from 'react-idle-timer';

+ const timerEvents = [
+  'pointerup',
+  'pointermove'
+ ] as const;

  const { pause, resume, reset } = useIdleTimer({
    element: document,
    timeout: 2000,
-  events: ['pointerup', 'pointermove'],
+  events: timerEvents as unknown as EVENTS[],
  });
```

Please let me know if I missed anything. Thanks again for maintaining such a useful library!