### PR TITLE
Fix getRemainingTime after hibernation

### DIFF
--- a/src/useIdleTimer.tsx
+++ b/src/useIdleTimer.tsx
@@ -558,6 +558,13 @@ export function useIdleTimer ({
     // If paused, return the current remaining time
     if (paused.current) return remaining.current
 
+    // If prompt is opened, it starts its own timer
+    if (promptTime.current) {
+      const promptLifetime = Math.floor(now() - promptTime.current);
+      const timeLeft = promptTimeoutRef.current - promptLifetime;
+      return Math.max(0, timeLeft);
+    }
+
     // Get how long the timer was set for
     const timeoutTotal = remaining.current
       ? remaining.current
@@ -569,7 +576,7 @@ export function useIdleTimer ({
       : 0
 
     const timeLeft = Math.floor(timeoutTotal - timeSinceLastActive)
-    return timeLeft < 0 ? 0 : Math.abs(timeLeft)
+    return Math.max(0, timeLeft);
   }, [timeoutRef, promptTimeoutRef, prompted, remaining, lastActive])
 
   /**


### PR DESCRIPTION
The problem is, that after hibernation the "prompt" is [triggered](https://github.com/SupremeTechnopriest/react-idle-timer/blob/d343d4d189dffe46c86dcc07b863da19cc98409a/src/useIdleTimer.tsx#L265) by timeout and Date.now.

But then `performance.now()` is [used](https://github.com/SupremeTechnopriest/react-idle-timer/blob/d343d4d189dffe46c86dcc07b863da19cc98409a/src/useIdleTimer.tsx#L568) to get the remaining time.

As a result, after hibernation, `getRemainingTime` function returns wrong result, because in real, idle callback will be called earlier.

So, I used `promptTime`, when prompt is shown, to detect the actual time, when `toggleIdleState` will be called.