### PR TITLE
Use .mjs extensions for ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
     ".": {
       "types": "./dist/index.d.ts",
       "require": "./dist/index.cjs.js",
-      "import": "./dist/index.esm.js"
+      "import": "./dist/index.esm.mjs"
     },
     "./legacy": {
       "types": "./dist/index.d.ts",
       "require": "./dist/index.legacy.cjs.js",
-      "import": "./dist/index.legacy.esm.js"
+      "import": "./dist/index.legacy.esm.mjs"
     }
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "5.7.2",
   "description": "Activity detection for React.js",
   "main": "./dist/index.cjs.js",
-  "module": "./dist/index.esm.js",
+  "module": "./dist/index.esm.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -6,9 +6,9 @@ const { es5Plugin } = require('esbuild-plugin-es5')
 
 const entry = './src/index.ts'
 const outLegacyCJS = './dist/index.legacy.cjs.js'
-const outLegacyESM = './dist/index.legacy.esm.js'
+const outLegacyESM = './dist/index.legacy.esm.mjs'
 const outCJS = './dist/index.cjs.js'
-const outESM = './dist/index.esm.js'
+const outESM = './dist/index.esm.mjs'
 
 // Clear destination folder
 fs.emptyDirSync('./dist')


### PR DESCRIPTION
Node interprets packages as CommonJS unless package `"type": "module"` is declared or `.mjs` extension is used.

This PR resolves this problem by using `.mjs` extensions for the ESM bundle.

- This yields `SyntaxError: Cannot use import statement outside a module` when importing this package
- https://publint.dev/react-idle-timer@5.7.2