### PR TITLE
Use arrow function notation in interface type

### DIFF
--- a/src/types/IIdleTimer.ts
+++ b/src/types/IIdleTimer.ts
@@ -4,35 +4,35 @@ export interface IIdleTimer {
    *
    * @returns whether the instance was started.
    */
-  start(): boolean
+  start: () => boolean
 
   /**
    * Restore initial state.
    *
    * @returns whether the instance was reset.
    */
-  reset(): boolean
+  reset: () => boolean
 
   /**
    * Restore initial state and emit onActive if the user was prompted or idle.
    *
    * @returns whether the instance was activated.
    */
-  activate(): boolean
+  activate: () => boolean
 
   /**
    * Store remaining time and stop timer.
    *
    * @returns whether the instance was paused.
    */
-  pause(): boolean
+  pause: () => boolean
 
   /**
    * Resumes a paused timer.
    *
    * @returns whether the instance was resumed.
    */
-  resume(): boolean
+  resume: () => boolean
 
   /**
    * Broadcast an arbitrary message to all instances of IdleTimer.
@@ -42,101 +42,101 @@ export interface IIdleTimer {
    *
    * @returns whether the message was sent.
    */
-  message(data: string | number | object, emitOnSelf?: boolean): boolean
+  message: (data: string | number | object, emitOnSelf?: boolean) => boolean
 
   /**
   * Returns whether the user is idle.
   *
   * @returns Idle state.
   */
-  isIdle(): boolean
+  isIdle: () => boolean
 
   /**
    * Returns whether the current tab is the leader.
    *
    * @returns Leader state.
    */
-  isLeader(): boolean
+  isLeader: () => boolean
 
   /**
    * Returns whether the prompt is active.
    *
    * @returns Prompted state.
    */
-  isPrompted(): boolean
+  isPrompted: () => boolean
 
   /**
    * Returns whether this is the last active tab.
    *
    * @returns Last active state.
    */
-  isLastActiveTab(): boolean
+  isLastActiveTab: () => boolean
 
   /**
    * Returns the current tabs id.
    */
-  getTabId(): string
+  getTabId: () => string
 
   /**
    * Time remaining before idle or prompt.
    *
    * @returns Number of milliseconds until idle or prompt.
    */
-  getRemainingTime(): number
+  getRemainingTime: () => number
 
   /**
    * Time elapsed since last reset.
    *
    * @returns Number of milliseconds since the hook was last reset.
    */
-  getElapsedTime(): number
+  getElapsedTime: () => number
 
   /**
    * Time elapsed since mounted.
    *
    * @returns Number of milliseconds since the hook was mounted.
    */
-  getTotalElapsedTime(): number
+  getTotalElapsedTime: () => number
 
   /**
    * Last time the user was idle.
    *
    * @returns A Date object that can be formatted.
    */
-  getLastIdleTime(): Date | null
+  getLastIdleTime: () => Date | null
 
   /**
    * Last time the user was active.
    *
    * @returns A Date object that can be formatted.
    */
-  getLastActiveTime(): Date | null
+  getLastActiveTime: () => Date | null
 
   /**
    * Time in milliseconds user has been idle since last reset.
    *
    * @returns Time in milliseconds the user has been idle.
    */
-  getIdleTime(): number
+  getIdleTime: () => number
 
   /**
    * Total time in milliseconds user has been idle since the hook mounted.
    *
    * @returns Time in milliseconds the user has been idle.
    */
-  getTotalIdleTime(): number
+  getTotalIdleTime: () => number
 
   /**
    * Total time in milliseconds user has been active since last reset.
    *
    * @returns Time in milliseconds the user has been active.
    */
-  getActiveTime(): number
+  getActiveTime: () => number
 
   /**
    * Total time in milliseconds user has been active since the hook mounted.
    *
    * @returns Time in milliseconds the user has been active.
    */
-  getTotalActiveTime(): number
+  getTotalActiveTime: () => number
 }


### PR DESCRIPTION
Fixes #360 

## Description
See #360. The current definitions throw typescript eslint errors and don't match the exported functions, in that the exported functions are arrow functions but the types are `function()` functions.

## Changes
* Update all function references in the `IIdleTimer` interface.
## Testing
See that everything still builds.